### PR TITLE
Add TwoPair scoring

### DIFF
--- a/files/04-Pairs/answers/first-pass/Hand.cs
+++ b/files/04-Pairs/answers/first-pass/Hand.cs
@@ -20,6 +20,7 @@ namespace CsharpPoker
             HasFullHouse() ? HandRank.FullHouse :
             HasFourOfAKind() ? HandRank.FourOfAKind :
             HasThreeOfAKind() ? HandRank.ThreeOfAKind :
+            HasTwoPair() ? HandRank.TwoPair :
             HasPair() ? HandRank.Pair :
             HandRank.HighCard;
 
@@ -30,7 +31,10 @@ namespace CsharpPoker
         // The Any LINQ method validates that there are dictionary items with a specified pair count value.
         private bool HasOfAKind(int num) => GetKindAndQuantities(cards).Any(c => c.Value == num);
 
+        private int CountOfAKind(int num) => GetKindAndQuantities(cards).Count(c => c.Value == num);
+
         private bool HasPair() => HasOfAKind(2);
+        private bool HasTwoPair() => CountOfAKind(2) == 2;
         private bool HasThreeOfAKind() => HasOfAKind(3);
         private bool HasFourOfAKind() => HasOfAKind(4);
 

--- a/files/04-Pairs/answers/first-pass/Tests/HandTests.cs
+++ b/files/04-Pairs/answers/first-pass/Tests/HandTests.cs
@@ -87,6 +87,18 @@ namespace CsharpPoker
         }
 
         [Fact]
+        public void CanScoreTwoPair()
+        {
+            var hand = new Hand();
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Clubs));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Spades));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Diamonds));
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Hearts));
+            hand.Draw(new Card(CardValue.Ace, CardSuit.Spades));
+            hand.GetHandRank().Should().Be(HandRank.TwoPair);
+        }
+
+        [Fact]
         public void CanScoreThreeOfAKind()
         {
             var hand = new Hand();

--- a/files/04-Pairs/answers/refactored/Hand.cs
+++ b/files/04-Pairs/answers/refactored/Hand.cs
@@ -24,6 +24,7 @@ namespace CsharpPoker
             HasFullHouse() ? HandRank.FullHouse :
             HasFourOfAKind() ? HandRank.FourOfAKind :
             HasThreeOfAKind() ? HandRank.ThreeOfAKind :
+            HasTwoPair() ? HandRank.TwoPair :
             HasPair() ? HandRank.Pair :
             HandRank.HighCard;
 
@@ -34,7 +35,10 @@ namespace CsharpPoker
         // The ToPairs extension method maps a collection of cards, to a collection of pairs.
         private bool HasOfAKind(int num) => cards.ToKindAndQuantities().Any(c => c.Value == num);
 
+        private int CountOfAKind(int num) => cards.ToKindAndQuantities().Count(c => c.Value == num);
+
         private bool HasPair() => HasOfAKind(2);
+        private bool HasTwoPair() => CountOfAKind(2) == 2;
         private bool HasThreeOfAKind() => HasOfAKind(3);
         private bool HasFourOfAKind() => HasOfAKind(4);
 

--- a/files/04-Pairs/answers/refactored/Tests/HandTests.cs
+++ b/files/04-Pairs/answers/refactored/Tests/HandTests.cs
@@ -93,6 +93,18 @@ namespace CsharpPoker
         }
 
         [Fact]
+        public void CanScoreTwoPair()
+        {
+            var hand = new Hand();
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Clubs));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Spades));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Diamonds));
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Hearts));
+            hand.Draw(new Card(CardValue.Ace, CardSuit.Spades));
+            hand.GetHandRank().Should().Be(HandRank.TwoPair);
+        }
+
+        [Fact]
         public void CanScoreThreeOfAKind()
         {
             var hand = new Hand();

--- a/files/05-Sequences/answers/first-pass/Hand.cs
+++ b/files/05-Sequences/answers/first-pass/Hand.cs
@@ -26,6 +26,7 @@ namespace CsharpPoker
             HasFullHouse() ? HandRank.FullHouse :
             HasFourOfAKind() ? HandRank.FourOfAKind :
             HasThreeOfAKind() ? HandRank.ThreeOfAKind :
+            HasTwoPair() ? HandRank.TwoPair :
             HasPair() ? HandRank.Pair :
             HandRank.HighCard;
 
@@ -34,8 +35,10 @@ namespace CsharpPoker
         private bool HasRoyalFlush() => HasFlush() && cards.All(c => c.Value > CardValue.Nine);
 
         private bool HasOfAKind(int num) => cards.ToKindAndQuantities().Any(c => c.Value == num);
+        private int CountOfAKind(int num) => cards.ToKindAndQuantities().Count(c => c.Value == num);
 
         private bool HasPair() => HasOfAKind(2);
+        private bool HasTwoPair() => CountOfAKind(2) == 2;
         private bool HasThreeOfAKind() => HasOfAKind(3);
         private bool HasFourOfAKind() => HasOfAKind(4);
 

--- a/files/05-Sequences/answers/first-pass/Tests/HandTests.cs
+++ b/files/05-Sequences/answers/first-pass/Tests/HandTests.cs
@@ -106,6 +106,18 @@ namespace CsharpPoker
         }
 
         [Fact]
+        public void CanScoreTwoPair()
+        {
+            var hand = new Hand();
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Clubs));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Spades));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Diamonds));
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Hearts));
+            hand.Draw(new Card(CardValue.Ace, CardSuit.Spades));
+            hand.GetHandRank().Should().Be(HandRank.TwoPair);
+        }
+
+        [Fact]
         public void CanScoreThreeOfAKind()
         {
             var hand = new Hand();

--- a/files/05-Sequences/answers/refactored/Hand.cs
+++ b/files/05-Sequences/answers/refactored/Hand.cs
@@ -26,6 +26,7 @@ namespace CsharpPoker
             HasFullHouse() ? HandRank.FullHouse :
             HasFourOfAKind() ? HandRank.FourOfAKind :
             HasThreeOfAKind() ? HandRank.ThreeOfAKind :
+            HasTwoPair() ? HandRank.TwoPair :
             HasPair() ? HandRank.Pair :
             HandRank.HighCard;
 
@@ -34,8 +35,10 @@ namespace CsharpPoker
         private bool HasRoyalFlush() => HasFlush() && cards.All(c => c.Value > CardValue.Nine);
 
         private bool HasOfAKind(int num) => cards.ToKindAndQuantities().Any(c => c.Value == num);
+        private int CountOfAKind(int num) => cards.ToKindAndQuantities().Count(c => c.Value == num);
 
         private bool HasPair() => HasOfAKind(2);
+        private bool HasTwoPair() => CountOfAKind(2) == 2;
         private bool HasThreeOfAKind() => HasOfAKind(3);
         private bool HasFourOfAKind() => HasOfAKind(4);
 

--- a/files/05-Sequences/answers/refactored/Tests/HandTests.cs
+++ b/files/05-Sequences/answers/refactored/Tests/HandTests.cs
@@ -95,6 +95,18 @@ namespace CsharpPoker
         }
 
         [Fact]
+        public void CanScoreTwoPair()
+        {
+            var hand = new Hand();
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Clubs));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Spades));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Diamonds));
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Hearts));
+            hand.Draw(new Card(CardValue.Ace, CardSuit.Spades));
+            hand.GetHandRank().Should().Be(HandRank.TwoPair);
+        }
+
+        [Fact]
         public void CanScoreThreeOfAKind()
         {
             var hand = new Hand();

--- a/files/06-Functional-refactor/answers/first-pass/Hand.cs
+++ b/files/06-Functional-refactor/answers/first-pass/Hand.cs
@@ -13,7 +13,9 @@ namespace CsharpPoker
         private bool HasFlush() => cards.All(c => cards.First().Suit == c.Suit);
         public bool HasRoyalFlush() => HasFlush() && cards.All(c => c.Value > CardValue.Nine);
         private bool HasOfAKind(int num) => cards.ToKindAndQuantities().Any(c => c.Value == num);
+        private int CountOfAKind(int num) => cards.ToKindAndQuantities().Count(c => c.Value == num);
         private bool HasPair() => HasOfAKind(2);
+        private bool HasTwoPair() => CountOfAKind(2) == 2;
         private bool HasThreeOfAKind() => HasOfAKind(3);
         private bool HasFourOfAKind() => HasOfAKind(4);
         private bool HasFullHouse() => HasThreeOfAKind() && HasPair();
@@ -28,6 +30,7 @@ namespace CsharpPoker
             HasFullHouse() ? HandRank.FullHouse :
             HasFourOfAKind() ? HandRank.FourOfAKind :
             HasThreeOfAKind() ? HandRank.ThreeOfAKind :
+            HasTwoPair() ? HandRank.TwoPair :
             HasPair() ? HandRank.Pair :
             HandRank.HighCard;
     }

--- a/files/06-Functional-refactor/answers/first-pass/Tests/HandTests.cs
+++ b/files/06-Functional-refactor/answers/first-pass/Tests/HandTests.cs
@@ -95,6 +95,18 @@ namespace CsharpPoker
         }
 
         [Fact]
+        public void CanScoreTwoPair()
+        {
+            var hand = new Hand();
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Clubs));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Spades));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Diamonds));
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Hearts));
+            hand.Draw(new Card(CardValue.Ace, CardSuit.Spades));
+            hand.GetHandRank().Should().Be(HandRank.TwoPair);
+        }
+
+        [Fact]
         public void CanScoreThreeOfAKind()
         {
             var hand = new Hand();

--- a/files/06-Functional-refactor/answers/refactored/FiveCardPokerScorer.cs
+++ b/files/06-Functional-refactor/answers/refactored/FiveCardPokerScorer.cs
@@ -10,7 +10,9 @@ namespace CsharpPoker
         private static bool HasFlush(IEnumerable<Card> cards) => cards.All(c => cards.First().Suit == c.Suit);
         private static bool HasRoyalFlush(IEnumerable<Card> cards) => HasFlush(cards) && cards.All(c => c.Value > CardValue.Nine);
         private static bool HasOfAKind(IEnumerable<Card> cards, int num) => cards.ToKindAndQuantities().Any(c => c.Value == num);
+        private static int CountOfAKind(IEnumerable<Card> cards, int num) => cards.ToKindAndQuantities().Count(c => c.Value == num);
         private static bool HasPair(IEnumerable<Card> cards) => HasOfAKind(cards, 2);
+        private static bool HasTwoPair(IEnumerable<Card> cards) => CountOfAKind(cards, 2) == 2;
         private static bool HasThreeOfAKind(IEnumerable<Card> cards) => HasOfAKind(cards, 3);
         private static bool HasFourOfAKind(IEnumerable<Card> cards) => HasOfAKind(cards, 4);
         private static bool HasFullHouse(IEnumerable<Card> cards) => HasThreeOfAKind(cards) && HasPair(cards);
@@ -33,6 +35,7 @@ namespace CsharpPoker
                        (cards => HasFlush(cards), HandRank.Flush),
                        (cards => HasStraight(cards), HandRank.Straight),
                        (cards => HasThreeOfAKind(cards), HandRank.ThreeOfAKind),
+                       (cards => HasTwoPair(cards), HandRank.TwoPair),
                        (cards => HasPair(cards), HandRank.Pair),
                        (cards => true, HandRank.HighCard),
            };

--- a/files/06-Functional-refactor/answers/refactored/Tests/ScoreTests.cs
+++ b/files/06-Functional-refactor/answers/refactored/Tests/ScoreTests.cs
@@ -65,6 +65,18 @@ namespace CsharpPoker.Tests
         }
 
         [Fact]
+        public void CanScoreTwoPair()
+        {
+            var hand = new Hand();
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Clubs));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Spades));
+            hand.Draw(new Card(CardValue.Jack, CardSuit.Diamonds));
+            hand.Draw(new Card(CardValue.Ten, CardSuit.Hearts));
+            hand.Draw(new Card(CardValue.Ace, CardSuit.Spades));
+            FiveCardPokerScorer.GetHandRank(hand.Cards).Should().Be(HandRank.TwoPair);
+        }
+
+        [Fact]
         public void CanScoreThreeOfAKind()
         {
             var hand = new Hand();


### PR DESCRIPTION
Along with #1 I noticed that the scoring did not handle the TwoPair case.

I wanted this change to be as minimal as possible but `HasOfAKind` could be changed to be
```c#
private bool HasOfAKind(int num) => CountOfAKind(num) > 0;
```

It did also occur to me that this was intentionally left out  so "no harm no foul" if you don't want to merge it.